### PR TITLE
Fix error when importing and cancelling file prompt

### DIFF
--- a/PaymentBalanceApplication/App.cs
+++ b/PaymentBalanceApplication/App.cs
@@ -110,19 +110,14 @@ internal partial class App : Form
 
     private void btnImport_Click(object sender, EventArgs e)
     {
+        bool doDelete = false;
         // ask user if they wish to delete any existing transactions
         if (tracker.HasTransactions)
         {
             DialogResult box = MessageBox.Show("There are existing transactions. Would you like to clear them?", "Clear Existing Transactions?", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question);
+            if (box == DialogResult.Cancel) return;
 
-            if (box == DialogResult.Yes)
-            {
-                tracker.ClearTransactions();
-            }
-            else if (box == DialogResult.Cancel)
-            {
-                return;
-            }
+            doDelete = box == DialogResult.Yes;
         }
 
         OpenFileDialog open = new OpenFileDialog();
@@ -132,6 +127,10 @@ internal partial class App : Form
         int additions = 0;
         if (open.ShowDialog() == DialogResult.OK)
         {
+            if (doDelete)
+            {
+                tracker.ClearTransactions();
+            }
             string[] lines = File.ReadAllLines(open.FileName);
 
             foreach (string line in lines)

--- a/PaymentBalanceApplication/Payment Tracker.csproj
+++ b/PaymentBalanceApplication/Payment Tracker.csproj
@@ -23,7 +23,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>13</ApplicationRevision>
+    <ApplicationRevision>15</ApplicationRevision>
     <ApplicationVersion>2.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>


### PR DESCRIPTION
In this PR, I fixed the error that caused an empty list on importing and cancelling via the `Open File Dialog`.

This includes
- Changing a pre-emptive deletion that occurred before a file was selected
- Updating minor revision value 